### PR TITLE
Fix root change detection & Fix Java client diff on version change

### DIFF
--- a/scripts/git-track/java.txt
+++ b/scripts/git-track/java.txt
@@ -1,0 +1,11 @@
+**/*.java
+**/*.md
+*.md
+*.gradle
+.gitignore
+.openapi-generator/
+gradlew
+gradlew.bat
+gradle/
+pom.xml
+LICENSE.txt

--- a/scripts/git-track/python.txt
+++ b/scripts/git-track/python.txt
@@ -1,0 +1,8 @@
+**/*.py
+**/*.md
+*.py
+*.md
+*.txt
+.gitignore
+.openapi-generator/
+tox.ini

--- a/scripts/push_sdk.sh
+++ b/scripts/push_sdk.sh
@@ -66,7 +66,7 @@ process() {
                          | grep -Ev 'version|VERSION|Version' \
                          | grep -Ev 'user_agent|UserAgent' \
                          | grep -Ev 'marketing\.java-client.+[0-9]\.[0-9]\.[0-9]' \
-                         | wc -l)
+                         | wc -l | tr -d '[:space:]')
   next_version=$(cat "/tmp/travis_${BUILD_NUMBER}-build_sdk-${language}.version")
 
   if [[ ${modification_count} != 0 && ${next_version} != "" ]]; then

--- a/scripts/push_sdk.sh
+++ b/scripts/push_sdk.sh
@@ -60,7 +60,13 @@ process() {
   git_add_files ${language}
 
   # git diff, ignore version's modifications
-  modification_count=$(git diff -U0 --staged | grep '^[+-]' | grep -Ev '^(--- a/|\+\+\+ b/)' | grep -Ev 'version|VERSION|Version|user_agent' | wc -l)
+  modification_count=$(git diff -U0 --staged \
+                         | grep '^[+-]' \
+                         | grep -Ev '^(--- a/|\+\+\+ b/)' \
+                         | grep -Ev 'version|VERSION|Version' \
+                         | grep -Ev 'user_agent|UserAgent' \
+                         | grep -Ev 'marketing\.java-client.+[0-9]\.[0-9]\.[0-9]' \
+                         | wc -l)
   next_version=$(cat "/tmp/travis_${BUILD_NUMBER}-build_sdk-${language}.version")
 
   if [[ ${modification_count} != 0 && ${next_version} != "" ]]; then

--- a/scripts/push_sdk.sh
+++ b/scripts/push_sdk.sh
@@ -20,21 +20,14 @@ setup_git() {
 }
 
 git_add_files() {
-  case "${1}" in
-    java)
-      files_to_add="**/*.java **/*.md"
-      files_to_add="${files_to_add} pom.xml *.gradle gradlew gradlew.bat gradle/"
-      files_to_add="${files_to_add} LICENSE.txt .gitignore .openapi-generator/"
-      ;;
-    python)
-      files_to_add="**/*.py **/*.md"
-      ;;
-    *)
-      exit 1
-      ;;
-  esac
-
-  git add ${files_to_add}
+  GIT_TRACK_FILE="${SCRIPT_ROOT}/git-track/${1}.txt"
+  if [[ -f ${GIT_TRACK_FILE} ]]; then
+      files_to_add=$(cat ${GIT_TRACK_FILE} | grep -Ev "^\s*#|^\s*$" | tr '\n' ' ')
+      git add ${files_to_add}
+  else
+    echo "'${GIT_TRACK_FILE}' does not exists, no files to add."
+    exit 1
+  fi
 }
 
 git_commit_and_tag() {


### PR DESCRIPTION

 **Fix root change detection**
 Bug description: Bash 4.x has a different behavior on `**/*` compared to bash 5.x: the root files are not taken into the consideration.

 Fix:
 * Add explicitly the files in the root directory.
 * Extract the files that we want to track into configuration files.

**Fix java client's diff on version change**

