### PR TITLE
Java client gradle build updates

### DIFF
--- a/build-java/resources/templates/build.gradle.mustache
+++ b/build-java/resources/templates/build.gradle.mustache
@@ -64,6 +64,10 @@ task sourcesJar(type: Jar) {
     archiveClassifier = 'sources'
 }
 
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 task javadocJar(type: Jar) {
     from javadoc
     archiveClassifier = 'javadoc'

--- a/build-java/resources/templates/build.gradle.mustache
+++ b/build-java/resources/templates/build.gradle.mustache
@@ -98,3 +98,7 @@ publishing {
 signing {
     sign publishing.publications.mavenJava
 }
+
+ext."signing.keyId" = '85532E9E'
+ext."signing.secretKeyRingFile" = '.travis/secring.gpg'
+ext."signing.password" = System.getenv("SONATYPE_PASSWORD")


### PR DESCRIPTION
- Use UTF-8 encoding always for the javaclient javadocs
- Add the artificat signing configuration for the javaclient