### PR TITLE
[Java client] Update OpenAPI Generator Gradle plugin to latest version

### DIFF
--- a/build-java/build.gradle
+++ b/build-java/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.openapitools:openapi-generator-gradle-plugin:4.0.0-beta2"
+        classpath "org.openapitools:openapi-generator-gradle-plugin:4.1.3"
     }
 }
 

--- a/build-java/resources/templates/ApiClient.mustache
+++ b/build-java/resources/templates/ApiClient.mustache
@@ -52,6 +52,7 @@ import java.util.regex.Pattern;
 
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
+import {{invokerPackage}}.auth.HttpBearerAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
 {{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
@@ -92,8 +93,9 @@ public class ApiClient {
     public ApiClient() {
         init();
 
-        // Setup authentications (key: authentication name, value: authentication).{{#authMethods}}{{#isBasic}}
-        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
+        // Setup authentications (key: authentication name, value: authentication).{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasicBasic}}{{^isBasicBasic}}
+        authentications.put("{{name}}", new HttpBearerAuth("{{scheme}}"));{{/isBasicBasic}}{{/isBasic}}{{#isApiKey}}
         authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
         authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
         authentications.put("CriteoHttpBasicAuth", new HttpBasicAuth());
@@ -141,7 +143,9 @@ public class ApiClient {
     {{/oauthMethods}}
     {{/hasOAuthMethods}}
     private void init() {
-        httpClient = new OkHttpClient();
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        builder.addNetworkInterceptor(getProgressInterceptor());
+        httpClient = builder.build();
 
         {{#useGzipFeature}}
         // Enable gzip request compression
@@ -188,13 +192,14 @@ public class ApiClient {
     }
 
     /**
-     * Set HTTP client
+     * Set HTTP client, which must never be null.
      *
-     * @param httpClient An instance of OkHttpClient
+     * @param newHttpClient An instance of OkHttpClient
      * @return Api Client
+     * @throws NullPointerException when newHttpClient is null
      */
-    public ApiClient setHttpClient(OkHttpClient httpClient) {
-        this.httpClient = httpClient;
+    public ApiClient setHttpClient(OkHttpClient newHttpClient) {
+        this.httpClient = Objects.requireNonNull(newHttpClient, "HttpClient must not be null!");
         return this;
     }
 
@@ -1071,12 +1076,12 @@ public class ApiClient {
      * @param headerParams The header parameters
      * @param formParams The form parameters
      * @param authNames The authentications to apply
-     * @param progressRequestListener Progress request listener
+     * @param callback Callback for upload/download progress
      * @return The HTTP call
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames, ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        Request request = buildRequest(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, progressRequestListener);
+    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
+        Request request = buildRequest(path, method, queryParams, collectionQueryParams, body, headerParams, formParams, authNames, callback);
 
         return httpClient.newCall(request);
     }
@@ -1092,11 +1097,11 @@ public class ApiClient {
      * @param headerParams The header parameters
      * @param formParams The form parameters
      * @param authNames The authentications to apply
-     * @param progressRequestListener Progress request listener
+     * @param callback Callback for upload/download progress
      * @return The HTTP request
      * @throws ApiException If fail to serialize the request body object
      */
-    public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames, ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+    public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
         if (!"/oauth2/token".equals(path)) {
             String explicitUserToken = headerParams.get("Authorization");
             if (explicitUserToken == null || explicitUserToken.isEmpty()) {
@@ -1135,10 +1140,14 @@ public class ApiClient {
             reqBody = serialize(body, contentType);
         }
 
+        // Associate callback with request (if not null) so interceptor can
+        // access it when creating ProgressResponseBody
+        reqBuilder.tag(callback);
+
         Request request = null;
 
-        if (progressRequestListener != null && reqBody != null) {
-            ProgressRequestBody progressRequestBody = new ProgressRequestBody(reqBody, progressRequestListener);
+        if (callback != null && reqBody != null) {
+            ProgressRequestBody progressRequestBody = new ProgressRequestBody(reqBody, callback);
             request = reqBuilder.method(method, progressRequestBody).build();
         } else {
             request = reqBuilder.method(method, reqBody).build();
@@ -1280,6 +1289,27 @@ public class ApiClient {
         } else {
             return contentType;
         }
+    }
+
+    /**
+     * Get network interceptor to add it to the httpClient to track download progress for
+     * async requests.
+     */
+    private Interceptor getProgressInterceptor() {
+        return new Interceptor() {
+            @Override
+            public Response intercept(Interceptor.Chain chain) throws IOException {
+                final Request request = chain.request();
+                final Response originalResponse = chain.proceed(request);
+                if (request.tag() instanceof ApiCallback) {
+                    final ApiCallback callback = (ApiCallback) request.tag();
+                    return originalResponse.newBuilder()
+                        .body(new ProgressResponseBody(originalResponse.body(), callback))
+                        .build();
+                }
+                return originalResponse;
+            }
+        };
     }
 
     /**

--- a/build-java/resources/templates/README.mustache
+++ b/build-java/resources/templates/README.mustache
@@ -75,8 +75,8 @@ mvn clean package
 
 Then manually install the following JARs:
 
-- `target/{{{artifactId}}}-{{{artifactVersion}}}.jar`
-- `target/lib/*.jar`
+* `target/{{{artifactId}}}-{{{artifactVersion}}}.jar`
+* `target/lib/*.jar`
 
 ## Example
 Please see [src/examples/java/com/criteo/marketing/](src/examples/java/com/criteo/marketing/) for full examples to get a valid token and make a call to the API.

--- a/build-java/resources/templates/build.gradle.mustache
+++ b/build-java/resources/templates/build.gradle.mustache
@@ -25,32 +25,33 @@ version = '{{artifactVersion}}'
 repositories {
     jcenter()
 }
-
 {{#sourceFolder}}
 sourceSets {
     main.java.srcDirs = ['{{sourceFolder}}']
 }
+
 {{/sourceFolder}}
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 
-install {
-    repositories.mavenInstaller {
-        pom.artifactId = '{{artifactId}}'
+    install {
+        repositories.mavenInstaller {
+            pom.artifactId = '{{artifactId}}'
+        }
     }
-}
 
 dependencies {
-    compile 'io.swagger:swagger-annotations:1.5.21'
-    compile 'com.squareup.okhttp3:okhttp:3.13.1'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.13.1'
+    compile 'io.swagger:swagger-annotations:1.5.22'
+    compile "com.google.code.findbugs:jsr305:3.0.2"
+    compile 'com.squareup.okhttp3:okhttp:3.14.2'
+    compile 'com.squareup.okhttp3:logging-interceptor:3.14.2'
     compile 'com.google.code.gson:gson:2.8.5'
     compile 'io.gsonfire:gson-fire:1.8.3'
     {{#hasOAuthMethods}}
     compile group: 'org.apache.oltu.oauth2', name: 'org.apache.oltu.oauth2.client', version: '1.0.1'
     {{/hasOAuthMethods}}
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     {{#joda}}
     compile 'joda-time:joda-time:2.9.9'
     {{/joda}}
@@ -68,6 +69,7 @@ task sourcesJar(type: Jar) {
 
 javadoc {
     options.encoding = 'UTF-8'
+    options.tags = [ "http.response.details:a:Http Response Details" ]
 }
 
 task javadocJar(type: Jar) {

--- a/build-java/resources/templates/pom.mustache
+++ b/build-java/resources/templates/pom.mustache
@@ -71,6 +71,7 @@
                             <value>conf/log4j.properties</value>
                         </property>
                     </systemProperties>
+                    <argLine>-Xms512m -Xmx1500m</argLine>
                     <parallel>methods</parallel>
                     <forkMode>pertest</forkMode>
                 </configuration>
@@ -151,6 +152,15 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <tags>
+                        <tag>
+                            <name>http.response.details</name>
+                            <placement>a</placement>
+                            <head>Http Response Details:</head>
+                        </tag>
+                    </tags>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -197,6 +207,12 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
+        </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
@@ -285,15 +301,15 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.3</gson-fire-version>
-        <swagger-core-version>1.5.21</swagger-core-version>
-        <okhttp-version>3.13.1</okhttp-version>
+        <swagger-core-version>1.5.22</swagger-core-version>
+        <okhttp-version>3.14.2</okhttp-version>
         <gson-version>2.8.5</gson-version>
-        <commons-lang3-version>3.8.1</commons-lang3-version>
+        <commons-lang3-version>3.9</commons-lang3-version>
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/joda}}
         {{#threetenbp}}
-        <threetenbp-version>1.3.5</threetenbp-version>
+        <threetenbp-version>1.3.8</threetenbp-version>
         {{/threetenbp}}
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>


### PR DESCRIPTION
In order to get rid of the beta version:
- upgrade gradle plugin
- adapt templates
- Now the templates supports HttpBearerAuth by default, but I kept our
workaround for the moment.