### PR TITLE
Update examples to use new Configuration constructor

### DIFF
--- a/build-python/resources/examples/authentication.py
+++ b/build-python/resources/examples/authentication.py
@@ -14,9 +14,7 @@ if __name__ == '__main__':
     if len(sys.argv) != 3:
         raise ValueError("You need to specify the CLIENT_ID and the CLIENT_SECRET")
 
-    configuration = Configuration()
-    configuration.username = sys.argv[1]
-    configuration.password = sys.argv[2]
+    configuration = Configuration(username=sys.argv[1], password=sys.argv[2])
 
     # Enable/Disable debug httplib and criteo_marketing packages
     # logging.basicConfig(level=logging.DEBUG)

--- a/build-python/resources/examples/statistics.py
+++ b/build-python/resources/examples/statistics.py
@@ -10,9 +10,7 @@ if __name__ == '__main__':
     if len(sys.argv) != 3:
         raise ValueError("You need to specify the CLIENT_ID and the CLIENT_SECRET")
 
-    configuration = Configuration()
-    configuration.username = sys.argv[1]
-    configuration.password = sys.argv[2]
+    configuration = Configuration(username=sys.argv[1], password=sys.argv[2])
 
     client = cm.ApiClient(configuration)
 


### PR DESCRIPTION
Since upgrade to OpenAPI Generator 4, it's easier to build the
Configuration object (it takes arguments now).